### PR TITLE
sets the environment variable SOFTWARE to an empty value

### DIFF
--- a/airprint_bridge.sh
+++ b/airprint_bridge.sh
@@ -18,6 +18,7 @@
 set +m
 
 # Forcing an English locale inside the script:
+export SOFTWARE=
 export LANG=C
 export LC_ALL=C
 


### PR DESCRIPTION
sets the environment variable SOFTWARE to an empty value. so the `lpstat` can output in right `LANG` as you set.